### PR TITLE
Accept stdin if no non-flag args are provided

### DIFF
--- a/cov/annotate.go
+++ b/cov/annotate.go
@@ -21,94 +21,94 @@
 package cov
 
 import (
-	"fmt"
-	"github.com/axw/gocov"
-	"go/token"
-	"io"
-	"io/ioutil"
-	"os"
-	"strings"
+    "fmt"
+    "github.com/axw/gocov"
+    "go/token"
+    "io"
+    "io/ioutil"
+    "os"
+    "strings"
 )
 
 const (
-	hitPrefix  = "    "
-	missPrefix = "MISS"
+    hitPrefix  = "    "
+    missPrefix = "MISS"
 )
 
 type annotator struct {
-	fset  *token.FileSet
-	files map[string]*token.File
+    fset  *token.FileSet
+    files map[string]*token.File
 }
 
 func annotateFunctionSource(w io.Writer, fn *gocov.Function) {
-	if fn == nil {
-		panic("nil function to annotate")
-	}
-	a := &annotator{}
-	a.fset = token.NewFileSet()
-	a.files = make(map[string]*token.File)
-	a.printFunctionSource(w, fn)
+    if fn == nil {
+        panic("nil function to annotate")
+    }
+    a := &annotator{}
+    a.fset = token.NewFileSet()
+    a.files = make(map[string]*token.File)
+    a.printFunctionSource(w, fn)
 }
 
 func (a *annotator) printFunctionSource(w io.Writer, fn *gocov.Function) error {
-	// Load the file for line information. Probably overkill, maybe
-	// just compute the lines from offsets in here.
-	setContent := false
-	file := a.files[fn.File]
-	if file == nil {
-		info, err := os.Stat(fn.File)
-		if err != nil {
-			return err
-		}
-		file = a.fset.AddFile(fn.File, a.fset.Base(), int(info.Size()))
-		setContent = true
-	}
+    // Load the file for line information. Probably overkill, maybe
+    // just compute the lines from offsets in here.
+    setContent := false
+    file := a.files[fn.File]
+    if file == nil {
+        info, err := os.Stat(fn.File)
+        if err != nil {
+            return err
+        }
+        file = a.fset.AddFile(fn.File, a.fset.Base(), int(info.Size()))
+        setContent = true
+    }
 
-	data, err := ioutil.ReadFile(fn.File)
-	if err != nil {
-		return err
-	}
+    data, err := ioutil.ReadFile(fn.File)
+    if err != nil {
+        return err
+    }
 
-	if setContent {
-		// This processes the content and records line number info.
-		file.SetLinesForContent(data)
-	}
+    if setContent {
+        // This processes the content and records line number info.
+        file.SetLinesForContent(data)
+    }
 
-	statements := fn.Statements[:]
-	lineno := file.Line(file.Pos(fn.Start))
-	lines := strings.Split(string(data)[fn.Start:fn.End], "\n")
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "<div class=\"funcname\" id=\"fn_%s\">%s</div>", fn.Name, fn.Name)
-	fmt.Fprintf(w, "<div class=\"info\"><a href=\"#s_fn_%s\">Back</a><p>In <code>%s</code>:</p></div>",
-		fn.Name, fn.File)
-	fmt.Fprintln(w, "<table class=\"listing\">")
-	for i, line := range lines {
-		lineno := lineno + i
-		statementFound := false
-		hit := false
-		for j := 0; j < len(statements); j++ {
-			start := file.Line(file.Pos(statements[j].Start))
-			if start == lineno {
-				statementFound = true
-				if !hit && statements[j].Reached > 0 {
-					hit = true
-				}
-				statements = append(statements[:j], statements[j+1:]...)
-			}
-		}
-		hitmiss := hitPrefix
-		if statementFound && !hit {
-			hitmiss = missPrefix
-		}
-		tr := "<tr"
-		if hitmiss == missPrefix {
-			tr += ` class="miss">`
-		} else {
-			tr += ">"
-		}
-		fmt.Fprintf(w, "%s<td>%d</td><td><pre>%s</pre></td></tr>", tr, lineno, strings.Replace(line, "\t", "        ", -1)) //TODO make the number of spaces an argument of printFunctionSource
-	}
-	fmt.Fprintln(w, "</table>")
+    statements := fn.Statements[:]
+    lineno := file.Line(file.Pos(fn.Start))
+    lines := strings.Split(string(data)[fn.Start:fn.End], "\n")
+    fmt.Fprintln(w)
+    fmt.Fprintf(w, "<div class=\"funcname\" id=\"fn_%s\">%s</div>", fn.Name, fn.Name)
+    fmt.Fprintf(w, "<div class=\"info\"><a href=\"#s_fn_%s\">Back</a><p>In <code>%s</code>:</p></div>",
+        fn.Name, fn.File)
+    fmt.Fprintln(w, "<table class=\"listing\">")
+    for i, line := range lines {
+        lineno := lineno + i
+        statementFound := false
+        hit := false
+        for j := 0; j < len(statements); j++ {
+            start := file.Line(file.Pos(statements[j].Start))
+            if start == lineno {
+                statementFound = true
+                if !hit && statements[j].Reached > 0 {
+                    hit = true
+                }
+                statements = append(statements[:j], statements[j+1:]...)
+            }
+        }
+        hitmiss := hitPrefix
+        if statementFound && !hit {
+            hitmiss = missPrefix
+        }
+        tr := "<tr"
+        if hitmiss == missPrefix {
+            tr += ` class="miss">`
+        } else {
+            tr += ">"
+        }
+        fmt.Fprintf(w, "%s<td>%d</td><td><pre>%s</pre></td></tr>", tr, lineno, strings.Replace(line, "\t", "        ", -1)) //TODO make the number of spaces an argument of printFunctionSource
+    }
+    fmt.Fprintln(w, "</table>")
 
-	return nil
+    return nil
 }

--- a/cov/const.go
+++ b/cov/const.go
@@ -21,8 +21,8 @@
 package cov
 
 const (
-	ProjectUrl = "https://github.com/matm/gocov-html"
-	htmlHeader = `<html>
+    ProjectUrl = "https://github.com/matm/gocov-html"
+    htmlHeader = `<html>
     <head>
         <title>Coverage Report</title>
         <!-- FIXME: Embedded style sheet -->
@@ -125,7 +125,7 @@ const (
         <div id="doctitle">Coverage<br/>Report</div>
     `
 
-	htmlFooter = `
+    htmlFooter = `
     </body>
 </html>`
 )

--- a/cov/report.go
+++ b/cov/report.go
@@ -21,177 +21,177 @@
 package cov
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/axw/gocov"
-	"io"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"sort"
-	"text/tabwriter"
-	"time"
+    "encoding/json"
+    "fmt"
+    "github.com/axw/gocov"
+    "io"
+    "io/ioutil"
+    "os"
+    "path/filepath"
+    "sort"
+    "text/tabwriter"
+    "time"
 )
 
 func unmarshalJson(data []byte) (packages []*gocov.Package, err error) {
-	result := &struct{ Packages []*gocov.Package }{}
-	err = json.Unmarshal(data, result)
-	if err == nil {
-		packages = result.Packages
-	}
-	return
+    result := &struct{ Packages []*gocov.Package }{}
+    err = json.Unmarshal(data, result)
+    if err == nil {
+        packages = result.Packages
+    }
+    return
 }
 
 type report struct {
-	packages []*gocov.Package
+    packages []*gocov.Package
 }
 
 type reportFunction struct {
-	*gocov.Function
-	statementsReached int
+    *gocov.Function
+    statementsReached int
 }
 
 type reportFunctionList []reportFunction
 
 func (l reportFunctionList) Len() int {
-	return len(l)
+    return len(l)
 }
 
 // TODO make sort method configurable?
 func (l reportFunctionList) Less(i, j int) bool {
-	var left, right float64
-	if len(l[i].Statements) > 0 {
-		left = float64(l[i].statementsReached) / float64(len(l[i].Statements))
-	}
-	if len(l[j].Statements) > 0 {
-		right = float64(l[j].statementsReached) / float64(len(l[j].Statements))
-	}
-	if left < right {
-		return true
-	}
-	return left == right && len(l[i].Statements) < len(l[j].Statements)
+    var left, right float64
+    if len(l[i].Statements) > 0 {
+        left = float64(l[i].statementsReached) / float64(len(l[i].Statements))
+    }
+    if len(l[j].Statements) > 0 {
+        right = float64(l[j].statementsReached) / float64(len(l[j].Statements))
+    }
+    if left < right {
+        return true
+    }
+    return left == right && len(l[i].Statements) < len(l[j].Statements)
 }
 
 func (l reportFunctionList) Swap(i, j int) {
-	l[i], l[j] = l[j], l[i]
+    l[i], l[j] = l[j], l[i]
 }
 
 type reverse struct {
-	sort.Interface
+    sort.Interface
 }
 
 func (r reverse) Less(i, j int) bool {
-	return r.Interface.Less(j, i)
+    return r.Interface.Less(j, i)
 }
 
 // NewReport creates a new report.
 func newReport() (r *report) {
-	r = &report{}
-	return
+    r = &report{}
+    return
 }
 
 // AddPackage adds a package's coverage information to the report.
 func (r *report) addPackage(p *gocov.Package) {
-	i := sort.Search(len(r.packages), func(i int) bool {
-		return r.packages[i].Name >= p.Name
-	})
-	if i < len(r.packages) && r.packages[i].Name == p.Name {
-		r.packages[i].Accumulate(p)
-	} else {
-		head := r.packages[:i]
-		tail := append([]*gocov.Package{p}, r.packages[i:]...)
-		r.packages = append(head, tail...)
-	}
+    i := sort.Search(len(r.packages), func(i int) bool {
+        return r.packages[i].Name >= p.Name
+    })
+    if i < len(r.packages) && r.packages[i].Name == p.Name {
+        r.packages[i].Accumulate(p)
+    } else {
+        head := r.packages[:i]
+        tail := append([]*gocov.Package{p}, r.packages[i:]...)
+        r.packages = append(head, tail...)
+    }
 }
 
 // Clear clears the coverage information from the report.
 func (r *report) clear() {
-	r.packages = nil
+    r.packages = nil
 }
 
 // PrintReport prints a coverage report to the given writer.
 func printReport(w io.Writer, r *report) {
-	w = tabwriter.NewWriter(w, 0, 8, 0, '\t', 0)
-	for _, pkg := range r.packages {
-		printPackage(w, pkg)
-		fmt.Fprintln(w)
-	}
+    w = tabwriter.NewWriter(w, 0, 8, 0, '\t', 0)
+    for _, pkg := range r.packages {
+        printPackage(w, pkg)
+        fmt.Fprintln(w)
+    }
 }
 
 func printPackage(w io.Writer, pkg *gocov.Package) {
-	functions := make(reportFunctionList, len(pkg.Functions))
-	for i, fn := range pkg.Functions {
-		reached := 0
-		for _, stmt := range fn.Statements {
-			if stmt.Reached > 0 {
-				reached++
-			}
-		}
-		functions[i] = reportFunction{fn, reached}
-	}
-	sort.Sort(reverse{functions})
+    functions := make(reportFunctionList, len(pkg.Functions))
+    for i, fn := range pkg.Functions {
+        reached := 0
+        for _, stmt := range fn.Statements {
+            if stmt.Reached > 0 {
+                reached++
+            }
+        }
+        functions[i] = reportFunction{fn, reached}
+    }
+    sort.Sort(reverse{functions})
 
-	var longestFunctionName int
-	var totalStatements, totalReached int
+    var longestFunctionName int
+    var totalStatements, totalReached int
 
-	fmt.Fprintf(w, htmlHeader)
-	fmt.Fprintf(w, "<div id=\"about\">Generated on<br/> %s<br/>with <a href=\"%s\">gocov-html</a></div>",
-		time.Now().Format(time.RFC822Z), ProjectUrl)
-	fmt.Fprintf(w, "<div class=\"package\">%s</div>\n", pkg.Name)
-	fmt.Fprintf(w, "<div id=\"totalcov\">%s</div>\n", pkg.Name)
-	fmt.Fprintf(w, "<table>\n")
-	for _, fn := range functions {
-		reached := fn.statementsReached
-		totalStatements += len(fn.Statements)
-		totalReached += reached
-		var stmtPercent float64 = 0
-		if len(fn.Statements) > 0 {
-			stmtPercent = float64(reached) / float64(len(fn.Statements)) * 100
-		}
-		if len(fn.Name) > longestFunctionName {
-			longestFunctionName = len(fn.Name)
-		}
-		fmt.Fprintf(w, "<tr id=\"s_fn_%s\"><td>%s/%s</td><td class=\"fn\"><code><a href=\"#fn_%s\">%s(...)</a></code></td><td class=\"percent\">%.2f%%</td><td class=\"linecount\">%d/%d</td></tr>\n",
-			fn.Name, pkg.Name, filepath.Base(fn.File), fn.Name, fn.Name, stmtPercent,
-			reached, len(fn.Statements))
-	}
+    fmt.Fprintf(w, htmlHeader)
+    fmt.Fprintf(w, "<div id=\"about\">Generated on<br/> %s<br/>with <a href=\"%s\">gocov-html</a></div>",
+        time.Now().Format(time.RFC822Z), ProjectUrl)
+    fmt.Fprintf(w, "<div class=\"package\">%s</div>\n", pkg.Name)
+    fmt.Fprintf(w, "<div id=\"totalcov\">%s</div>\n", pkg.Name)
+    fmt.Fprintf(w, "<table>\n")
+    for _, fn := range functions {
+        reached := fn.statementsReached
+        totalStatements += len(fn.Statements)
+        totalReached += reached
+        var stmtPercent float64 = 0
+        if len(fn.Statements) > 0 {
+            stmtPercent = float64(reached) / float64(len(fn.Statements)) * 100
+        }
+        if len(fn.Name) > longestFunctionName {
+            longestFunctionName = len(fn.Name)
+        }
+        fmt.Fprintf(w, "<tr id=\"s_fn_%s\"><td>%s/%s</td><td class=\"fn\"><code><a href=\"#fn_%s\">%s(...)</a></code></td><td class=\"percent\">%.2f%%</td><td class=\"linecount\">%d/%d</td></tr>\n",
+            fn.Name, pkg.Name, filepath.Base(fn.File), fn.Name, fn.Name, stmtPercent,
+            reached, len(fn.Statements))
+    }
 
-	var funcPercent float64
-	if totalStatements > 0 {
-		funcPercent = float64(totalReached) / float64(totalStatements) * 100
-	}
-	fmt.Fprintf(w, "<tr><td>%s</td><td></td><td class=\"percent\">%.2f%%</td><td class=\"linecount\">%d/%d</td></tr>\n",
-		pkg.Name, funcPercent,
-		totalReached, totalStatements)
-	fmt.Fprintf(w, "</table>\n")
+    var funcPercent float64
+    if totalStatements > 0 {
+        funcPercent = float64(totalReached) / float64(totalStatements) * 100
+    }
+    fmt.Fprintf(w, "<tr><td>%s</td><td></td><td class=\"percent\">%.2f%%</td><td class=\"linecount\">%d/%d</td></tr>\n",
+        pkg.Name, funcPercent,
+        totalReached, totalStatements)
+    fmt.Fprintf(w, "</table>\n")
 
-	// Embbed function source code
-	for _, fn := range functions {
-		annotateFunctionSource(w, fn.Function)
-	}
+    // Embbed function source code
+    for _, fn := range functions {
+        annotateFunctionSource(w, fn.Function)
+    }
 
-	fmt.Fprintf(w, "<script type=\"text/javascript\">\ndocument.getElementById(\"totalcov\").textContent = \"%.2f%%\"\n</script>", funcPercent)
-	fmt.Fprintf(w, "\n<!-- Can be parsed by external script\nPACKAGE:%s DONE:%.2f\n-->\n",
-		pkg.Name, funcPercent)
-	fmt.Fprintf(w, htmlFooter)
+    fmt.Fprintf(w, "<script type=\"text/javascript\">\ndocument.getElementById(\"totalcov\").textContent = \"%.2f%%\"\n</script>", funcPercent)
+    fmt.Fprintf(w, "\n<!-- Can be parsed by external script\nPACKAGE:%s DONE:%.2f\n-->\n",
+        pkg.Name, funcPercent)
+    fmt.Fprintf(w, htmlFooter)
 }
 
 func HTMLReportCoverage(r io.Reader) error {
-	report := newReport()
-	data, err := ioutil.ReadAll(r)
-	if err != nil {
-		return fmt.Errorf("failed to read coverage data: %s\n", err)
-	}
+    report := newReport()
+    data, err := ioutil.ReadAll(r)
+    if err != nil {
+        return fmt.Errorf("failed to read coverage data: %s\n", err)
+    }
 
-	packages, err := unmarshalJson(data)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal coverage data: %s\n", err)
-	}
+    packages, err := unmarshalJson(data)
+    if err != nil {
+        return fmt.Errorf("failed to unmarshal coverage data: %s\n", err)
+    }
 
-	for _, pkg := range packages {
-		report.addPackage(pkg)
-	}
-	fmt.Println()
-	printReport(os.Stdout, report)
-	return nil
+    for _, pkg := range packages {
+        report.addPackage(pkg)
+    }
+    fmt.Println()
+    printReport(os.Stdout, report)
+    return nil
 }

--- a/gocov-html.go
+++ b/gocov-html.go
@@ -21,31 +21,31 @@
 package main
 
 import (
-	"flag"
-	"github.com/cznic/gocov-html/cov"
-	"io"
-	"log"
-	"os"
+    "flag"
+    "github.com/cznic/gocov-html/cov"
+    "io"
+    "log"
+    "os"
 )
 
 func main() {
-	log.SetFlags(0)
-	flag.Parse()
-	var r io.Reader
-	switch flag.NArg() {
-	case 0:
-		r = os.Stdin
-	case 1:
-		var err error
-		if r, err = os.Open(flag.Arg(0)); err != nil {
-			log.Fatal(err)
-		}
+    log.SetFlags(0)
+    flag.Parse()
+    var r io.Reader
+    switch flag.NArg() {
+    case 0:
+        r = os.Stdin
+    case 1:
+        var err error
+        if r, err = os.Open(flag.Arg(0)); err != nil {
+            log.Fatal(err)
+        }
 
-	default:
-		log.Fatalf("Usage: %s data.json\n", os.Args[0])
-	}
+    default:
+        log.Fatalf("Usage: %s data.json\n", os.Args[0])
+    }
 
-	if err := cov.HTMLReportCoverage(r); err != nil {
-		log.Fatal(err)
-	}
+    if err := cov.HTMLReportCoverage(r); err != nil {
+        log.Fatal(err)
+    }
 }


### PR DESCRIPTION
Makes it more usable in scripts, makefiles etc.

Also `go fmt` the whole tree. Could have saved a confusing diff if that
have been used in the first place.

---

Example of the same behavior: https://code.google.com/p/go/source/browse/src/cmd/vet/main.go#91

PS: Please always use `go fmt` before publishing any code. Not `go fmt <anyone's-personal-preferences-options>`, just `go fmt`. Instead, please set your preferences in your favorite editor, to show the code in the way you prefer.

Note: In case you'll accept this pull request then you have to s/cznic/matm/ at https://github.com/cznic/gocov-html/blob/master/gocov-html.go#L25

ERROR: Argh, pushed version N-1. `flag.Arg(0)` should be in the func main(), not `flag.Arg(1)`
