### PR TITLE
Implement location-based sort order

### DIFF
--- a/cmd/gocov-html/main.go
+++ b/cmd/gocov-html/main.go
@@ -42,6 +42,7 @@ func main() {
 	listThemes := flag.Bool("lt", false, "list available themes")
 	theme := flag.String("t", "golang", "theme to use for rendering")
 	reverseOrder := flag.Bool("r", false, "put lower coverage functions on top")
+	sortOrder := flag.String("sort", "high-coverage", "sort functions by high-coverage, low-coverage or location")
 	maxCoverage := flag.Uint64("cmax", 100, "only show functions whose coverage is greater than cmax")
 	minCoverage := flag.Uint64("cmin", 0, "only show functions whose coverage is smaller than cmin")
 
@@ -81,6 +82,15 @@ func main() {
 		return
 	}
 
+	var sortOrderOpt themes.SortOrder = themes.SortOrder(*sortOrder)
+	if !sortOrderOpt.Valid() {
+		log.Fatalf("Invalid sort order: %q\n", sortOrderOpt)
+	}
+
+	if *reverseOrder {
+		sortOrderOpt = themes.SortOrderLowCoverage
+	}
+
 	switch flag.NArg() {
 	case 0:
 		r = os.Stdin
@@ -94,10 +104,10 @@ func main() {
 	}
 
 	opts := themes.ReportOptions{
-		LowCoverageOnTop: *reverseOrder,
-		Stylesheet:       *css,
-		CoverageMin:      uint8(*minCoverage),
-		CoverageMax:      uint8(*maxCoverage),
+		SortOrder:   sortOrderOpt,
+		Stylesheet:  *css,
+		CoverageMin: uint8(*minCoverage),
+		CoverageMax: uint8(*maxCoverage),
 	}
 	if err := themes.HTMLReportCoverage(r, opts); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
In code base with a lot of inline functions it can be hard to read a coverage report where they are all ordered by the coverage number.

This adds a new flag for ordering functions based on their location.